### PR TITLE
Removed unnecessary 'AllOf' constructs

### DIFF
--- a/osdm-wrapper/OMSA-001.yaml
+++ b/osdm-wrapper/OMSA-001.yaml
@@ -3190,8 +3190,7 @@ components:
 
     # referenced data
     externalReference:
-      allOf:
-        - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     organisationReference:
       type: object
@@ -3222,12 +3221,10 @@ components:
           $ref: "#/components/schemas/normalString"
 
     customerReference:
-      allOf:
-        - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     travellerReference:
-      allOf:
-        - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     productReference:
       type: object
@@ -3241,20 +3238,16 @@ components:
           $ref: "#/components/schemas/normalString"
 
     offerReference:
-      allOf:
-      - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     packageReference:
-      allOf:
-        - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     legReference:
-      allOf:
-        - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     lineReference:
-      allOf:
-        - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     zoneReference:
       type: object
@@ -3297,8 +3290,7 @@ components:
           $ref: "#/components/schemas/normalString"
 
     serviceJourneyReference:
-      allOf:
-        - $ref: "#/components/schemas/normalString"
+      $ref: "#/components/schemas/normalString"
 
     userNeedReference:
       type: object


### PR DESCRIPTION
closes #2 
I think the 'allOf's were applied to avoid warnings when you add descriptions. But we don't use `description:`, so it's indeed not necessary to have them.