### PR TITLE
chore(spec): Refactor OpenAPI spec for consistency and clarity

### DIFF
--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -236,7 +236,7 @@ paths:
 
   /processes/assign-ancillary/execute:
     post:
-      operationId: assignAncillaryProcessHandler
+      operationId: assignAncillaryHandler
       summary: "Handles assigning ancillary processes"
       security:
         - BearerAuth: []
@@ -278,7 +278,7 @@ paths:
 
   /processes/purchase-offers/execute:
     post:
-      operationId: purchaseOffersProcessHandler
+      operationId: purchaseOffersHandler
       summary: "Handles purchase of offers"
       security:
         - BearerAuth: []
@@ -320,7 +320,7 @@ paths:
 
   /processes/purchase-package/execute:
     post:
-      operationId: purchasePackageProcessHandler
+      operationId: purchasePackageHandler
       summary: "Handles purchase processes"
       security:
         - BearerAuth: []
@@ -362,7 +362,7 @@ paths:
 
   /processes/2-phase-purchase-package/execute:
     post:
-      operationId: twoPhasePurchasePackageProcessHandler
+      operationId: twoPhasePurchasePackageHandler
       summary: "Handles purchase processes"
       security:
         - BearerAuth: []
@@ -373,9 +373,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/bbox"
       requestBody:
         required: true
         content:
@@ -407,7 +404,7 @@ paths:
 
   /processes/confirm-package/execute:
     post:
-      operationId: confirmPackageProcessHandler
+      operationId: confirmPackageHandler
       summary: "Handles purchase processes"
       security:
         - BearerAuth: []
@@ -418,9 +415,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/bbox"
       requestBody:
         required: true
         content:
@@ -452,7 +446,7 @@ paths:
 
   /processes/release-package/execute:
     post:
-      operationId: releasePackageProcessHandler
+      operationId: releasePackageHandler
       summary: "Handles purchase processes"
       security:
         - BearerAuth: []
@@ -463,9 +457,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/offset"
-        - $ref: "#/components/parameters/bbox"
       requestBody:
         required: true
         content:
@@ -523,11 +514,23 @@ paths:
         "200":
           $ref: "#/components/responses/packageResponse"
         default:
+      callbacks:
+        jobCompleted:
+          '{$request.body#/subscriber/successUri}':
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/package'
+              responses:
+                "200":
+                  description: Results received successfully
           $ref: "#/components/responses/errorResponse"
 
   /processes/cancel-package/execute:
     post:
-      operationId: cancelPackageProcessHandler
+      operationId: cancelPackageHandler
       summary: "Handles cancel package processes"
       security:
         - BearerAuth: []
@@ -569,7 +572,7 @@ paths:
 
   /processes/claim-refund-option/execute:
     post:
-      operationId: claimRefundProcessHandler
+      operationId: claimRefundHandler
       summary: "Handles claim of refund options"
       security:
         - BearerAuth: []
@@ -611,7 +614,7 @@ paths:
 
   /processes/confirm-refund-option/execute:
     post:
-      operationId: confirmRefundClaimProcessHandler
+      operationId: confirmRefundClaimHandler
       summary: "Handles confirmation of the refund claim"
       security:
         - BearerAuth: []
@@ -1313,7 +1316,6 @@ components:
         properties:
           type:
             type: string
-            pattern: "^(search_offer)"
             enum: [ search_offer ]
           specification:
             allOf:
@@ -1398,7 +1400,6 @@ components:
           type:
             type: string
             enum: [ refund-option ]
-            pattern: "^(refund-option)$"
           reason:
             $ref: "#/components/schemas/normalString"
           refundType:
@@ -1415,7 +1416,6 @@ components:
         type:
           type: string
           enum: [ claim_refund_option, confirm_refund_option ]
-          pattern: "^(claim_refund_option|confirm_refund_option)$"
         optionId:
           $ref: "#/components/schemas/uuid"
 
@@ -1429,7 +1429,6 @@ components:
         type:
           type: string
           enum: [ traveller ]
-          pattern: "^(traveller)$"
         travellerId:
           $ref: "#/components/schemas/travellerReference"
         packageId:
@@ -1453,7 +1452,6 @@ components:
             $ref: "#/components/schemas/legReference"
           type:
             type: string
-            pattern: "^(change_times)"
             enum: [ change_times ]
 
     assetInput:
@@ -1522,7 +1520,6 @@ components:
           type:
             type: string
             enum: [ redress ]
-            pattern: "^(redress)"
           redressOptionId:
             $ref: "#/components/schemas/uuid"
 
@@ -1535,7 +1532,6 @@ components:
         properties:
           type:
             type: string
-            pattern: "^(extend_expiry_time)"
             enum: [ extend_expiry_time ]
           extensionReason:
             type: string
@@ -2291,7 +2287,6 @@ components:
         properties:
           type:
             type: string
-            pattern: "^(asset)$"
             enum: [ asset ]
           id:
             $ref: "#/components/schemas/assetReference"


### PR DESCRIPTION
This PR introduces a series of refactoring changes to the `OMSA.yaml` specification to improve its overall quality, consistency, and logical structure. Each change addresses a specific type of inconsistency, making the API more predictable and easier for developers to work with.

#### Summary of Changes and Rationale:

1.  **Standardized `operationId` Suffix**

      * **Change:** All process `operationId`s have been standardized to use the shorter `...Handler` suffix (e.g., `cancelPackageProcessHandler` is now `cancelPackageHandler`).
      * **Reason:** This enforces a single, consistent naming convention across all endpoints, which improves readability and predictability.

2.  **Removed Inapplicable Query Parameters**

      * **Change:** Pagination and bounding box parameters (`limit`, `offset`, `bbox`) have been removed from several `POST` endpoints (`2-phase-purchase-package`, `confirm-package`, etc.).
      * **Reason:** These parameters are designed for querying collections of data (typically via `GET`) and are not logical for single-action commands. Removing them clarifies the intended use of these endpoints and prevents potential misuse or confusion for API clients.


3.  **Added Missing `callbacks` Block**

      * **Change:** The `extend-expiry-time` process was missing its `callbacks` block. This has been added.
      * **Reason:** This endpoint represents an asynchronous operation, similar to other processes in the API. Adding the `callbacks` block makes it consistent with the others, ensuring that clients can handle all async operations in a uniform and expected manner.

4.  **Removed Redundant `pattern` Validations**

      * **Change:** Removed `pattern` validations from various schemas where a restrictive `enum` was already present.
      * **Reason:** The `pattern` validation was superfluous as the `enum` already provided a stricter constraint on the allowed values. This cleanup removes unnecessary verbosity and simplifies the schema definitions without altering validation logic.


---

Closes #25 #26 #27 #28

---

_Origin (internal reference): https://github.com/entur/OMSA-spec/pull/5_
