### PR TITLE
feat(spec): Add missing add-traveller process endpoint

### DIFF
--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -108,6 +108,48 @@ paths:
                 "200":
                   description: Results received successfully
 
+  /processes/add-traveller/execute:
+    post:
+      operationId: addTravellerHandler
+      summary: Add a new traveller to a package
+      security:
+        - BearerAuth: []
+        - OAuth: []
+        - OAuthPKI: []
+      tags:
+        - processes
+      parameters:
+        - $ref: "#/components/parameters/acceptLanguage"
+        - $ref: "#/components/parameters/authorization"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                inputs:
+                  $ref: "#/components/schemas/travellerInput"
+                subscriber:
+                  $ref: "#/components/schemas/subscriber"
+      responses:
+        "200":
+          $ref: "#/components/responses/packageResponse"
+        default:
+          $ref: "#/components/responses/errorResponse"
+      callbacks:
+        jobCompleted:
+          "{$request.body#/subscriber/successUri}":
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: "#/components/schemas/package"
+              responses:
+                "200":
+                  description: Results received successfully
+
   /processes/update-traveller/execute:
     post:
       operationId: updateTravellerHandler


### PR DESCRIPTION
The `add-traveller` process was referenced in the `processID enum` but lacked a corresponding path definition.

This commit adds the `/processes/add-traveller/execute` endpoint to the specification, modeled after the existing `update-traveller` endpoint for consistency. This resolves the discrepancy and completes the process API definition.


---

Closes #29

---

_Origin (internal reference): https://github.com/entur/OMSA-spec/pull/4_
