### PR TITLE
fix(spec): Correct typos and inconsistencies in OMSA.yaml

### DIFF
--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -38,6 +38,7 @@ paths:
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/bbox"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -79,6 +80,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -120,6 +122,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -161,6 +164,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -202,6 +206,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -243,6 +248,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -284,6 +290,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -325,6 +332,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -369,6 +377,7 @@ paths:
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/bbox"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -413,6 +422,7 @@ paths:
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/bbox"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -457,6 +467,7 @@ paths:
         - $ref: "#/components/parameters/offset"
         - $ref: "#/components/parameters/bbox"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -498,6 +509,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -527,6 +539,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -568,6 +581,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -609,6 +623,7 @@ paths:
         - $ref: "#/components/parameters/acceptLanguage"
         - $ref: "#/components/parameters/authorization"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -981,6 +996,7 @@ paths:
       tags:
       - authentication
       requestBody:
+        required: true
         content:
           application/x-www-form-urlencoded:
             schema:

--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Common Booking API
   version: 0.0.1
- 
+
 servers:
   - url: https://example.b5/
     description: example url
@@ -497,7 +497,7 @@ paths:
 
   /processes/extend-expiry-time/execute:
     post:
-      operationId: extendExpiryTimerocessHandler
+      operationId: extendExpiryTimeProcessHandler
       summary: "Handles extending expiry time"
       security:
         - BearerAuth: []
@@ -726,7 +726,7 @@ paths:
 
   /collections/travel-documents/items:
     get:
-      operationId: traveldocumentsCollectionHandler
+      operationId: travelDocumentsCollectionHandler
       summary: "Handles travel documents"
       security:
         - OpenData: []
@@ -806,7 +806,7 @@ paths:
       responses:
         '200':
           description: General Success response.
-          content: 
+          content:
             application/yaml:
               schema:
                 type: string
@@ -965,12 +965,15 @@ paths:
               - assign-asset
               - assign-ancillary
               - purchase-offer
-              - 2-phase-purchase-offer
-              - confirm-offer
-              - release-offer
+              - select-offers
+              - 2-phase-purchase-package
+              - confirm-package
+              - release-package
               - purchase-package
               - extend-expiry-time
               - cancel-package
+              - claim-refund-option
+              - confirm-refund-option
       responses:
         '200':
           description: A process description.
@@ -989,9 +992,9 @@ paths:
   /oauth/token:
     post:
       summary: "Token Endpoint"
-      description: This endpoint is used to obtain an access token and optionally an ID token 
+      description: This endpoint is used to obtain an access token and optionally an ID token
         through different OAuth 2.0 grant types, including Client Credentials Flow.
-        Whenever the mTLS flow is taken, the properties will be ignored, and the access token 
+        Whenever the mTLS flow is taken, the properties will be ignored, and the access token
         will be generated based on the credentials in the certificate (O or CN).
       tags:
       - authentication
@@ -1094,7 +1097,7 @@ components:
         text/html:
           schema:
             type: string
-    
+
     collectionResponse:
       description: the response of the collection endpoint
       headers:
@@ -1267,7 +1270,7 @@ components:
         removed from the API definition, if conformance class **'callback'**
         is not listed in the conformance declaration under `/conformance`.
       required:
-        - successUrl
+        - successUri
       properties:
         successUri:
           type: string
@@ -1303,7 +1306,7 @@ components:
 
     # Inputs
     searchOfferInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/defaultInput"
       - type: object
         required:
@@ -1336,7 +1339,7 @@ components:
                 propertyName: type
 
     selectOffersInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/defaultInput"
       - type: object
         required:
@@ -1347,12 +1350,12 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/offerReference"
-          type: 
+          type:
             type: string
             enum: [ select_offers ]
 
     packageInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/defaultInput"
       - type: object
         required:
@@ -1361,35 +1364,35 @@ components:
         properties:
           packageId:
             $ref: "#/components/schemas/packageReference"
-          type: 
+          type:
             type: string
             enum: [ package ]
 
     legInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/packageInput"
       - type: object
         required:
         - legId
         - type
         properties:
-          offerId: 
+          offerId:
             $ref: "#/components/schemas/offerReference"
           legId:
             $ref: "#/components/schemas/legReference"
           type:
             type: string
             enum: [ leg ]
-          location: 
+          location:
             $ref: "#/components/schemas/placeReference"
          #evidence:
          #   type: array
          #   minItems: 1
          #   items:
-         #     $ref: "#/components/schemas/link"                      
+         #     $ref: "#/components/schemas/link"
 
     refundInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/legInput"
       - type: object
         required:
@@ -1424,7 +1427,7 @@ components:
       required:
         - type
         - packageId
-        - id
+        - travellerId
       properties:
         type:
           type: string
@@ -1441,7 +1444,7 @@ components:
             - $ref: "#/components/schemas/travellingAsset"
 
     travelSpecificationInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/packageInput"
       - $ref: "#/components/schemas/travelSpecification"
       - type: object
@@ -1457,7 +1460,7 @@ components:
             enum: [ change_times ]
 
     assetInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/legInput"
       - type: object
         required:
@@ -1473,7 +1476,7 @@ components:
             $ref: "#/components/schemas/assetReference"
 
     ancillaryInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/legInput"
       - type: object
         required:
@@ -1512,7 +1515,7 @@ components:
               enum: [ purchase_offers ]
 
     redressInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/packageInput"
       - type: object
         required:
@@ -1527,7 +1530,7 @@ components:
             $ref: "#/components/schemas/uuid"
 
     extendExpiryTimeInput:
-      allOf: 
+      allOf:
       - $ref: "#/components/schemas/packageInput"
       - type: object
         required:
@@ -1724,7 +1727,7 @@ components:
       - $ref: "#/components/schemas/travelSpecification"
       - $ref: "#/components/schemas/placeDefinitions"
       - type: object
-        description: a purchased package is a registration of an agreement between end user and TO, 
+        description: a purchased package is a registration of an agreement between end user and TO,
           to execute a package (=set of legs) according a specification, including all conditions
         required:
           - type
@@ -1787,7 +1790,7 @@ components:
                 $ref: "#/components/schemas/product"
             price:
               $ref: "#/components/schemas/amountOfMoney"
-            summary: 
+            summary:
               type: object
               additionalProperties: true
             guarantees:
@@ -1804,7 +1807,7 @@ components:
     leg:
       x-tm: LEG
       allOf:
-        - $ref: "#/components/schemas/travelSpecification"        
+        - $ref: "#/components/schemas/travelSpecification"
         - type: object
           description: A (planned) consumption of a product within a package
           required:
@@ -1856,7 +1859,7 @@ components:
         type:
           type: string
           enum: [ product ]
-        productId: 
+        productId:
           $ref: "#/components/schemas/productReference"
         productName:
           $ref: "#/components/schemas/normalString"
@@ -1943,13 +1946,13 @@ components:
           QRCODE: "#/components/schemas/binaryTicket"
           AZTECCODE: "#/components/schemas/binaryTicket"
       required:
-        - startvalidity
-        - endvalidity
+        - startValidity
+        - endValidity
         - travelDocumentType
       properties:
-        startvalidity:
+        startValidity:
           $ref: "#/components/schemas/dateTime"
-        endvalidity:
+        endValidity:
           $ref: "#/components/schemas/dateTime"
         travelDocumentType:
           $ref: "#/components/schemas/typeOfTravelDocument"
@@ -1974,7 +1977,7 @@ components:
 
     # Transmodel based objects
     mode:
-      x-tm: 
+      x-tm:
       - concept: MODE
       type: string
       description: These classes are taken from the NeTeX standard, but ALL and UNKNOWN are removed. On the other hand OTHER and PARKING are added.
@@ -2113,7 +2116,7 @@ components:
       properties:
         type:
           type: string
-      
+
     postalAddress:
       x-tm: POSTAL ADDRESS
       type: object
@@ -2605,7 +2608,7 @@ components:
     cancellationParameter:
       allOf:
       - $ref: "#/components/schemas/parameter"
-      - x-tm: 
+      - x-tm:
         - concept: CANCELLING
         - cancellationFee: lacking
         - cancellationAllowed: cancellationAllowed
@@ -2633,7 +2636,7 @@ components:
     purchaseParameter:
       allOf:
       - $ref: "#/components/schemas/parameter"
-      - x-tm: 
+      - x-tm:
         - concept: PURCHASE WINDOW
         - maximumPeriodBeforeDeparture: MaximumPeriodBeforeDeparture
         - requiredLicenseTypes: ENTITLEMENT REQUIRED
@@ -2826,7 +2829,7 @@ components:
           items:
             type: object
             properties:
-              id: 
+              id:
                 $ref: "#/components/schemas/normalString"
               properties:
                 $ref: "#/components/schemas/ancillary"
@@ -2844,7 +2847,7 @@ components:
             actions that can be performed on this package, but also alternative (rel=alternative+1, alternative+2) offers or references to other resources
             In case it is an alternative, specify clearly in the description what the financial consequences are.
           items:
-            $ref: "#/components/schemas/link"    
+            $ref: "#/components/schemas/link"
 
     refundOptionCollection:
       type: object
@@ -2859,7 +2862,7 @@ components:
           items:
             type: object
             properties:
-              id: 
+              id:
                 $ref: "#/components/schemas/normalString"
               properties:
                 $ref: "#/components/schemas/refundOption"
@@ -2877,7 +2880,7 @@ components:
             actions that can be performed on this package, but also alternative (rel=alternative+1, alternative+2) offers or references to other resources
             In case it is an alternative, specify clearly in the description what the financial consequences are.
           items:
-            $ref: "#/components/schemas/link"  
+            $ref: "#/components/schemas/link"
 
     travelDocumentCollection:
       type: object
@@ -2892,7 +2895,7 @@ components:
           items:
             type: object
             properties:
-              id: 
+              id:
                 $ref: "#/components/schemas/normalString"
               properties:
                 oneOf:
@@ -2914,7 +2917,7 @@ components:
             actions that can be performed on this package, but also alternative (rel=alternative+1, alternative+2) offers or references to other resources
             In case it is an alternative, specify clearly in the description what the financial consequences are.
           items:
-            $ref: "#/components/schemas/link"  
+            $ref: "#/components/schemas/link"
 
     ancillary:
       allOf:
@@ -2926,7 +2929,7 @@ components:
             enum: [ ancillary ]
           links:
             type: array
-            items: 
+            items:
               $ref: "#/components/schemas/link"
 
     seat:
@@ -3180,7 +3183,7 @@ components:
           $ref: "#/components/schemas/tinyString"
 
     externalTicket:
-      x-tm: 
+      x-tm:
       - concept: TRAVEL DOCUMENT
       description: External ticket, can be accessed using the links collection, with rel=ticket
       type: object
@@ -3219,7 +3222,7 @@ components:
               description: how it advertises itself
 
     otherAccessInfo:
-      x-tm: 
+      x-tm:
       - concept: lacking
       description: Generic travelDocument, non-standardized (yet)
       allOf:
@@ -3295,7 +3298,7 @@ components:
       properties:
         organisationId:
           $ref: "#/components/schemas/normalString"
-        name: 
+        name:
           $ref: "#/components/schemas/normalString"
 
     placeReference:
@@ -3303,9 +3306,9 @@ components:
       required:
       - placeId
       properties:
-        placeId: 
+        placeId:
           type: string
-          description: this string references to information that can be found in the `data sources`. 
+          description: this string references to information that can be found in the `data sources`.
             Enlist all prefixes (=rel) from the /collections/datasources/items that apply to a place/location.
             Default it matches already with 'GPS' (no entry required in the datasources).
             In case of a custom place (like home address), you can use the 'P:' prefix and add the
@@ -3332,7 +3335,7 @@ components:
       properties:
         productId:
           $ref: "#/components/schemas/normalString"
-        name: 
+        name:
           $ref: "#/components/schemas/normalString"
 
     offerReference:
@@ -3358,7 +3361,7 @@ components:
       properties:
         zoneId:
           $ref: "#/components/schemas/normalString"
-        name: 
+        name:
           $ref: "#/components/schemas/normalString"
 
     assetReference:
@@ -3368,7 +3371,7 @@ components:
       properties:
         assetId:
           $ref: "#/components/schemas/normalString"
-        name: 
+        name:
           $ref: "#/components/schemas/normalString"
 
     ancillaryReference:
@@ -3378,7 +3381,7 @@ components:
       properties:
         ancillaryId:
           $ref: "#/components/schemas/normalString"
-        name: 
+        name:
           $ref: "#/components/schemas/normalString"
 
     equipmentReference:
@@ -3388,7 +3391,7 @@ components:
       properties:
         equipmentId:
           $ref: "#/components/schemas/normalString"
-        name: 
+        name:
           $ref: "#/components/schemas/normalString"
 
     serviceJourneyReference:
@@ -3402,7 +3405,7 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/normalString"
-        name: 
+        name:
           $ref: "#/components/schemas/normalString"
 
     # base types
@@ -3648,7 +3651,7 @@ components:
         description: >-
           A comma-separated list of BCP 47 (RFC 5646) language tags and optional
           weights as described in IETF RFC7231 section 5.3.5. A list of the
-          languages/localizations the user would like to see the results in. 
+          languages/localizations the user would like to see the results in.
           For user privacy and ease of use on the TO side, this list should be
           kept as short as possible
     authorization:


### PR DESCRIPTION
This commit applies a series of straightforward fixes to the OpenAPI specification to improve its accuracy and consistency.

The changes include:
- Correcting typos in `operationId`s.
- Aligning process enum values with endpoints (changing "...-offer" to "...-package").
- Fixing incorrect field names in `required` lists (`successUrl` -> `successUri`, `id` -> `travellerId`).
- Standardizing property names to camelCase (`startvalidity` -> `startValidity`).


---

Closes #30 #31 #32

---

_Origin (internal reference): https://github.com/entur/OMSA-spec/pull/3_
