### PR TITLE
feat(spec): Support component-based ancillary pricing and selection

### DIFF
--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -1601,12 +1601,23 @@ components:
       - type: object
         required:
         - type
-        - offerIds
+        - selections
         properties:
-          offerIds:
+          selections:
             type: array
+            description: "Component-based selection of offers and their ancillaries."
             items:
-              $ref: "#/components/schemas/offerReference"
+              type: object
+              required:
+                - offerId
+              properties:
+                offerId:
+                  $ref: "#/components/schemas/offerReference"
+                selectedAncillaryIds:
+                  type: array
+                  description: "List of ancillaryIds to include specifically for this offer instance."
+                  items:
+                    $ref: "#/components/schemas/ancillaryReference"
           type:
             type: string
             enum: [ select_offers ]
@@ -3084,6 +3095,15 @@ components:
           type:
             type: string
             enum: [ ancillary ]
+          price:
+            $ref: "#/components/schemas/amountOfMoney"
+            description: "The additional cost of this ancillary if selected."
+          description:
+            type: string
+            description: "A user-friendly description of the ancillary (e.g. 'Reserved seat for bike')."
+          available:
+            type: integer
+            description: "Number of items available in stock (inventory). Useful for creating urgency in GUI."
           links:
             type: array
             items:


### PR DESCRIPTION
## Summary

This PR introduces explicit, component-based modelling of ancillaries in OMSA and replaces the previous offerIds-only select-offers flow with an explicit selections structure.

### Changes

- Extend the "ancillary" schema with:
  - "price" (amountOfMoney): additional cost for the ancillary if selected.
  - "description" (string): user-friendly description suitable for GUI.
  - "available" (integer): remaining stock count (optional).
- Change "selectOffersInput" to support only component-based selections:
  - Introduce a required "selections" array with entries containing:
    - "offerId" (offerReference): offer being selected.
    - "selectedAncillaryIds" (array of ancillaryReference): ancillaries chosen for this offer instance.
  - Remove the previous flat "offerIds" list.

### Motivation

Many implementations use component-based pricing where search returns base offers plus optional ancillaries with their own prices. Clients need to:

- Display ancillaries as independent, priced options (e.g. "Add dog for 50", "Add bike for 100").
- Create multiple instances of the same base offer with different ancillary combinations.

The previous OMSA model made this difficult because ancillaries did not carry their own prices and select-offers only accepted a flat list of offerIds.