### PR TITLE
Remove timestamp property from request schema

### DIFF
--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -1303,9 +1303,6 @@ components:
       properties:
         type:
           type: string
-        timestamp:
-          description: timestamp of request
-          $ref: "#/components/schemas/dateTime"
 
     landingPage:
       type: object


### PR DESCRIPTION
This pull request makes a small change to the `OMSA.yaml` file by removing the `timestamp` property from a schema definition.

Closes #58 