### PR TITLE
Refactor placeDefinitions schema to simplify structure

### DIFF
--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -1531,7 +1531,10 @@ components:
           specification:
             allOf:
             - $ref: "#/components/schemas/requestedTravelSpecification"
-            - $ref: "#/components/schemas/placeDefinitions"
+            - type: object
+              properties:
+                placeDefinitions:
+                  $ref: "#/components/schemas/placeDefinitions"
           pattern:
             $ref: "#/components/schemas/tripPattern"
           packageToExchange:
@@ -1904,7 +1907,6 @@ components:
       x-tm: TRAVEL OFFER PACKAGE, CUSTOMER PURCHASE PACKAGE
       allOf:
       - $ref: "#/components/schemas/travelSpecification"
-      - $ref: "#/components/schemas/placeDefinitions"
       - type: object
         description: a purchased package is a registration of an agreement between end user and TO,
           to execute a package (=set of legs) according a specification, including all conditions
@@ -1914,6 +1916,8 @@ components:
           - price
           - offers
         properties:
+          placeDefinitions:
+            $ref: "#/components/schemas/placeDefinitions"
           type:
             type: string
             enum: [ package ]
@@ -3152,15 +3156,12 @@ components:
         maxProperties: 20
 
     placeDefinitions:
-      type: object
-      properties:
-        placeDefinitions:
-          description: Places that are not specified in an external data source (like a home address)
-          type: array
-          minItems: 0
-          maxItems: 3
-          items:
-            $ref: "#/components/schemas/postalAddress"
+      description: Places that are not specified in an external data source (like a home address)
+      type: array
+      minItems: 0
+      maxItems: 3
+      items:
+        $ref: "#/components/schemas/postalAddress"
 
     binaryTicket:
       allOf:


### PR DESCRIPTION
Schema reference and structure improvements:

* Changed the `specification` section to reference `placeDefinitions` as a property within an object, instead of using `allOf` for direct inclusion.
* Removed direct `allOf` inclusion of `placeDefinitions` in the `purchasedPackage` schema, and instead added it as a property in the schema definition. [[1]](diffhunk://#diff-bc11ef4a18880f6176c6cc3be5007bbde052e7d2c78118111d0b943e57a67383L1907) [[2]](diffhunk://#diff-bc11ef4a18880f6176c6cc3be5007bbde052e7d2c78118111d0b943e57a67383R1919-R1920)

Definition cleanup:
* Removed the previous object-based definition of `placeDefinitions` and replaced it with a more descriptive array-based schema, clarifying its intended use.

Closes #60 